### PR TITLE
feat: update Dockerfile and Makefile and eliminate CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o namespace-cleaner ./cmd/na
 
 FROM gcr.io/distroless/static:nonroot
 
-COPY --from=builder /app/namespace-cleaner /
+COPY --from=builder /app/namespace-cleaner /usr/local/bin/namespace-cleaner
 USER nonroot:nonroot
 
-ENTRYPOINT ["/namespace-cleaner"]
+ENTRYPOINT ["/bin/sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,12 @@
-# Stage 1: Build Go binary
-FROM golang:1.24.2 as builder
+FROM golang:1.24.2 AS builder
 
-# Set up Go workspace
 WORKDIR /app
-
-# Copy Go source
 COPY . .
-
-# Build static binary
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o namespace-cleaner ./cmd/namespace-cleaner
 
-# Stage 2: Minimal runtime image
-FROM debian:bullseye-slim
+FROM gcr.io/distroless/static:nonroot
 
-# Install kubectl with version pinning and cleanup
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    ca-certificates=20210119 \
-    curl=7.74.0-1.3+deb11u14 && \
-    curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" && \
-    install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl && \
-    rm kubectl && \
-    apt-get purge -y --auto-remove curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/namespace-cleaner /
+USER nonroot:nonroot
 
-# Copy the binary from the builder stage to the runtime image
-COPY --from=builder /app/namespace-cleaner /usr/local/bin/namespace-cleaner
-
-# Default command - let Kubernetes override this with args if needed
-ENTRYPOINT ["/bin/sh"]
+ENTRYPOINT ["/namespace-cleaner"]

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ test: build
 		-f tests/test-config.yaml \
 		-f tests/test-cases.yaml
 	kubectl run testpod \
-		--image bitnami/kubectl:latest \
+		--image gcr.io/distroless/static:nonroot \
 		--restart=Never \
 		--env DRY_RUN=false \
 		--env TEST_MODE=true \


### PR DESCRIPTION
no more usage of kubectl means we can remove docker containers for running kubectl and instead use something smaller and with fewer attack surfaces.