### PR TITLE
chore: clean up dry-run output and refactor namespace logic

### DIFF
--- a/cmd/namespace-cleaner/main_test.go
+++ b/cmd/namespace-cleaner/main_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
@@ -223,7 +222,7 @@ func (s *NamespaceCleanerTestSuite) TestProcessNamespaces() {
 // TestDryRunBehavior verifies that no modifications are made when DryRun is enabled.
 // Expected outcome: Namespace labels should remain unchanged after processing.
 func TestDryRunBehavior(t *testing.T) {
-	ns := &v1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "dry-run-ns",
 			Labels: map[string]string{
@@ -259,7 +258,7 @@ func TestDryRunBehavior(t *testing.T) {
 // TestLabelParsingErrors validates handling of invalid timestamp formats in labels.
 // Expected outcome: Invalid labels should be removed from namespaces.
 func TestLabelParsingErrors(t *testing.T) {
-	ns := &v1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "invalid-label-ns",
 			Labels: map[string]string{
@@ -294,7 +293,7 @@ func TestLabelParsingErrors(t *testing.T) {
 // TestValidNamespace ensures valid namespaces with active users remain unmodified.
 // Expected outcome: No deletion labels added to valid namespaces.
 func TestValidNamespace(t *testing.T) {
-	ns := &v1.Namespace{
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "valid-ns",
 			Labels: map[string]string{


### PR DESCRIPTION
Mostly did a bunch of code reorganization. Nothing major, just small changes for clarity.

## Summary of Changes

This PR includes various improvements to the `namespace-cleaner` tool, primarily focused on improving dry-run output clarity, refactoring, and defensive coding. Key changes include:

### 🧠 Code Improvements

* **Refactored**:

  * `initGraphClient` now properly receives `context.Context`.
  * More idiomatic checking for the presence of the `owner` annotation using Go's multi-return map lookup pattern:

    ```go
    email, found := ns.Annotations["owner"]
    ```
* **Grace period parsing** in `getGracePeriod` now includes better logging and clearer fallbacks for invalid or negative values.

### 🔍 Dry Run Enhancements

* Improved `DryRun` logs:

  * Now logs early if a namespace is missing the `owner` annotation or has an invalid domain.
  * Adds `Examining namespace: ...` messages even when the `owner` is missing.
  * Moves up and consolidates dry-run log messages for more coherent output per namespace.

### 🧪 Testing Adjustments

* Minor cleanup in `main_test.go`:

  * Removed redundant import alias (`v1` for `corev1`).
  * Replaced use of `v1.Namespace{}` with the clearer `corev1.Namespace{}`.