### PR TITLE
feat(cronjob): add ttlSecondsAfterFinished: 128

### DIFF
--- a/manifests/cronjob.yaml
+++ b/manifests/cronjob.yaml
@@ -7,6 +7,7 @@ metadata:
   labels:
     app: namespace-cleaner
 spec:
+  ttlSecondsAfterFinished: 128
   schedule: "0 0 * * *"
   jobTemplate:
     spec:


### PR DESCRIPTION
### Context:

- When the namespace-cleaner is done it leaves its job pod.

### Todo:

- [ ] Edit the cronjob to delete its working pod when done.

### Expected Outcome:

- No leftover pods when the namespace-cleaner is done.