### PR TITLE
chore(image): reference local images for dry run and cronjob

### DIFF
--- a/manifests/cronjob.yaml
+++ b/manifests/cronjob.yaml
@@ -18,7 +18,7 @@ spec:
           serviceAccountName: namespace-cleaner
           containers:
             - name: namespace-cleaner-container
-              image: artifactory.cloud.statcan.ca/das-aaw-docker/namespace-cleaner:8b2fbb8021fa613e9f09932dc19291ecb746dc36
+              image: namespace-cleaner:test
               command: ["/namespace-cleaner"]
               envFrom:
                 - secretRef:

--- a/tests/dry-run-job.yaml
+++ b/tests/dry-run-job.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: namespace-cleaner
       containers:
         - name: cleaner
-          image: artifactory.cloud.statcan.ca/das-aaw-docker/namespace-cleaner:b6e48d75b149194c14d23c146affb0e9fdc68ffb
+          image: namespace-cleaner:test
           command: ["/namespace-cleaner", "-dry-run"]
           envFrom:
             - secretRef:


### PR DESCRIPTION
### Context:

* The github repo has the full repo url along with sha
* This sha is going to be almost always out of date

### Todo:

* Update Job and CronJob to use a local image
* Update Gitlab ArgoCD Manifest Dev Repo with latest SHA
* Update README.md

### Expected Outcome:

* manifests no longer use repo
* no more shas to update 

### Links:

- JIRA: https://jirab.statcan.ca/browse/BTIS-997